### PR TITLE
fix: RoomService 추가 기능 구현 및 개선

### DIFF
--- a/src/room/dto/update-guestname.dto.ts
+++ b/src/room/dto/update-guestname.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class UpdateGuestNameDto {
+  @IsString()
+  @ApiProperty({ type: String, description: '게스트ID' })
+  guestId!: string;
+
+  @IsString()
+  @ApiProperty({ type: String, description: '바꿀 이름' })
+  name!: string;
+}

--- a/src/room/room.controller.ts
+++ b/src/room/room.controller.ts
@@ -15,8 +15,10 @@ import { JwtAuthGuard } from 'src/shared/guards/jwt.guard';
 import { UserService } from 'src/user/user.service';
 import { CreateRoomBodyDTO } from './dto/create-room-body.dto';
 import { CreateRoomDTO } from './dto/create-room.dto';
+import { UpdateGuestNameDto } from './dto/update-guestname.dto';
 import { UpdateRoomDTO } from './dto/update-room.dto';
 import { Room } from './room.entity';
+import { RoomMemberDocument } from './room.schema';
 import { RoomControllService } from './services/room-controll.service';
 import { RoomMemberService } from './services/room-member.service';
 import { RoomService } from './services/room.service';
@@ -102,6 +104,20 @@ export class RoomController {
   @ApiInternalServerErrorResponse({ description: JSON.stringify(RoomError.ROOM_FAIL_INVITECODE) })
   async updateInviteCode(@Param('roomId') roomId: number): Promise<Room> {
     const room = await this.roomService.updateInviteCode(roomId);
+    return room;
+  }
+
+  @Put('/:roomId/guestname')
+  @ApiBody({ type: UpdateGuestNameDto })
+  @ApiParam({ name: 'roomId', type: Number })
+  @ApiOkResponse()
+  @ApiNotFoundResponse()
+  async updateGuestName(
+    @Param('roomId') roomId: number,
+    @Body() updateGuestNameDto: UpdateGuestNameDto
+  ): Promise<RoomMemberDocument> {
+    const { guestId, name } = updateGuestNameDto;
+    const room = await this.roomControllService.changeGuestName(roomId, guestId, name);
     return room;
   }
 

--- a/src/room/room.controller.ts
+++ b/src/room/room.controller.ts
@@ -17,6 +17,7 @@ import { CreateRoomBodyDTO } from './dto/create-room-body.dto';
 import { CreateRoomDTO } from './dto/create-room.dto';
 import { UpdateRoomDTO } from './dto/update-room.dto';
 import { Room } from './room.entity';
+import { RoomControllService } from './services/room-controll.service';
 import { RoomMemberService } from './services/room-member.service';
 import { RoomService } from './services/room.service';
 
@@ -26,6 +27,7 @@ export class RoomController {
   constructor(
     private readonly roomService: RoomService,
     private readonly roomMemberService: RoomMemberService,
+    private readonly roomControllService: RoomControllService,
     private readonly userService: UserService
   ) {}
 
@@ -46,6 +48,7 @@ export class RoomController {
     createRoomDto.maxPeople = createRoomBodyDto.maxPeople;
 
     const room = await this.roomService.create(createRoomDto);
+    await this.roomControllService.joinRoom(room.roomId, room.owner.uuid);
     return room;
   }
 

--- a/src/room/room.controller.ts
+++ b/src/room/room.controller.ts
@@ -48,7 +48,9 @@ export class RoomController {
     createRoomDto.maxPeople = createRoomBodyDto.maxPeople;
 
     const room = await this.roomService.create(createRoomDto);
-    await this.roomControllService.joinRoom(room.roomId, room.owner.uuid);
+    await this.roomControllService.joinRoom(room.roomId, {
+      userId: uuid
+    });
     return room;
   }
 

--- a/src/room/room.gateway.ts
+++ b/src/room/room.gateway.ts
@@ -27,11 +27,13 @@ export class RoomGateway {
     @MessageBody() data: JoinSocketRequest
   ): Promise<WsResponse<unknown>> {
     try {
-      const { inviteCode } = data;
+      const { inviteCode, name } = data;
 
       const { roomId } = await this.roomService.getRoomByCode(inviteCode);
 
-      const result = await this.roomControllService.joinRoom(roomId);
+      const result = await this.roomControllService.joinRoom(roomId, {
+        name
+      });
       socket.join(`room-${roomId}`);
 
       return {
@@ -49,9 +51,9 @@ export class RoomGateway {
     @MessageBody() data: QuitSocketRequest
   ): Promise<WsResponse<unknown>> {
     try {
-      const { roomId, userId } = data;
+      const { roomId, guestId } = data;
 
-      await this.roomControllService.quitRoom(roomId, userId);
+      await this.roomControllService.quitRoom(roomId, guestId);
       socket.leave(`room-${roomId}`);
 
       return {

--- a/src/room/room.schema.ts
+++ b/src/room/room.schema.ts
@@ -1,5 +1,6 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
+import { MemberData } from 'src/types/member-data';
 
 @Schema({
   versionKey: false
@@ -9,7 +10,7 @@ export class RoomMember {
   roomId!: number;
 
   @Prop()
-  members!: string[];
+  members!: MemberData[];
 }
 
 export type RoomMemberDocument = RoomMember & Document;

--- a/src/room/services/room-controll.service.ts
+++ b/src/room/services/room-controll.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { WsException } from '@nestjs/websockets';
 import { RoomError } from 'src/shared/errors/room.error';
 import { RoomInteractReturn } from 'src/types';
-import { v4 as uuidv4 } from 'uuid';
 import { RoomMemberService } from './room-member.service';
 import { RoomService } from './room.service';
 
@@ -10,6 +9,7 @@ interface JoinRoomOption {
   readonly name?: string;
   readonly userId?: string;
 }
+const WORD_DATA = 'abcdefghijklmnopqrstuvwxyz1234567890';
 
 @Injectable()
 export class RoomControllService {
@@ -19,7 +19,12 @@ export class RoomControllService {
   ) {}
 
   private generateGuestId(): string {
-    return uuidv4();
+    let result = '';
+    for (let i = 0; i < 8; i += 1) {
+      const rand = Math.floor(Math.random() * WORD_DATA.length);
+      result += WORD_DATA[rand];
+    }
+    return result;
   }
 
   async joinRoom(roomId: number, options: JoinRoomOption): Promise<RoomInteractReturn> {

--- a/src/room/services/room-controll.service.ts
+++ b/src/room/services/room-controll.service.ts
@@ -60,6 +60,9 @@ export class RoomControllService {
     const guestIndex = roomMember.members.findIndex((i) => i.id === guestId);
     if (guestIndex === -1) throw new WsException(RoomError.GUEST_NOT_FOUND);
 
+    const guest = roomMember.members[guestIndex];
+    if (guest.owner) throw new WsException(RoomError.OWNER_CAN_NOT_QUIT);
+
     roomMember.members.splice(guestIndex, 1);
     await roomMember.save();
   }

--- a/src/room/services/room-controll.service.ts
+++ b/src/room/services/room-controll.service.ts
@@ -57,10 +57,8 @@ export class RoomControllService {
 
     const roomMember = await this.roomMemberService.getRoomMember(roomId);
 
-    const existsMember = roomMember.members.find((user) => user.id === guestId);
-    if (!existsMember) throw new WsException(RoomError.GUEST_NOT_FOUND);
-
     const guestIndex = roomMember.members.findIndex((i) => i.id === guestId);
+    if (guestIndex === -1) throw new WsException(RoomError.GUEST_NOT_FOUND);
 
     roomMember.members.splice(guestIndex, 1);
     await roomMember.save();

--- a/src/shared/errors/room.error.ts
+++ b/src/shared/errors/room.error.ts
@@ -28,5 +28,9 @@ export const RoomError: ErrorInfo = {
   ROOM_FAIL_INVITECODE: {
     code: 'room-500',
     message: '초대코드 생성을 실패하였습니다. 다시 시도해주세요.'
+  },
+  OWNER_CAN_NOT_QUIT: {
+    code: 'room-400',
+    message: '방장은 방을 나갈 수 없습니다. 방 삭제를 이용해주세요.'
   }
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,6 @@ export interface JwtPayload {
 }
 
 export interface RoomInteractReturn {
-  readonly guestId: string;
+  readonly id: string;
   readonly roomInfo: Room;
 }

--- a/src/types/member-data.ts
+++ b/src/types/member-data.ts
@@ -1,5 +1,5 @@
 export interface MemberData {
   readonly id: string;
   readonly owner: boolean;
-  readonly name?: string;
+  name?: string;
 }

--- a/src/types/member-data.ts
+++ b/src/types/member-data.ts
@@ -1,0 +1,5 @@
+export interface MemberData {
+  readonly id: string;
+  readonly owner: boolean;
+  readonly name?: string;
+}

--- a/src/types/socket.ts
+++ b/src/types/socket.ts
@@ -1,8 +1,9 @@
 export interface JoinSocketRequest {
   readonly inviteCode: string;
+  readonly name: string;
 }
 
 export interface QuitSocketRequest {
   readonly roomId: number;
-  readonly userId: string;
+  readonly guestId: string;
 }


### PR DESCRIPTION
### 변경
- 방 생성 시 방장을 자동으로 방 멤버에 추가하도록 변경하였습니다.
- 방장, 게스트를 구분하고 게스트의 이름을 정할 수 있도록 방 멤버 구조를 변경하였습니다.
- 방장은 방을 퇴장할 수 없도록 변경하였습니다.
  - 방장이 나가고 싶으면 방을 삭제해야 합니다.
- 게스트ID를 UUID가 아닌 8글자 랜덤 알파벳, 숫자로 변경하였습니다.
- **일부 소켓 API의 요청 양식을 변경하였습니다. 🔥 문서 확인 필요**

### 추가
- 게스트 이름을 바꾸는 API를 구현하였습니다.
