### PR TITLE
feat: 방 도메인 관련 API 및 소켓 구현

### DIFF
--- a/src/room/room.controller.ts
+++ b/src/room/room.controller.ts
@@ -46,9 +46,6 @@ export class RoomController {
     createRoomDto.maxPeople = createRoomBodyDto.maxPeople;
 
     const room = await this.roomService.create(createRoomDto);
-    await this.roomControllService.joinRoom(room.roomId, {
-      userId: createRoomBodyDto.owner
-    });
     return room;
   }
 

--- a/src/room/room.controller.ts
+++ b/src/room/room.controller.ts
@@ -12,7 +12,6 @@ import {
 } from '@nestjs/swagger';
 import { RoomError } from 'src/shared/errors/room.error';
 import { JwtAuthGuard } from 'src/shared/guards/jwt.guard';
-import { UserService } from 'src/user/user.service';
 import { CreateRoomBodyDTO } from './dto/create-room-body.dto';
 import { CreateRoomDTO } from './dto/create-room.dto';
 import { UpdateGuestNameDto } from './dto/update-guestname.dto';
@@ -22,6 +21,7 @@ import { RoomMemberDocument } from './room.schema';
 import { RoomControllService } from './services/room-controll.service';
 import { RoomMemberService } from './services/room-member.service';
 import { RoomService } from './services/room.service';
+import { MemberData } from '../types/member-data';
 
 @Controller('room')
 @ApiTags('room')
@@ -29,8 +29,7 @@ export class RoomController {
   constructor(
     private readonly roomService: RoomService,
     private readonly roomMemberService: RoomMemberService,
-    private readonly roomControllService: RoomControllService,
-    private readonly userService: UserService
+    private readonly roomControllService: RoomControllService
   ) {}
 
   @Post()
@@ -73,6 +72,18 @@ export class RoomController {
   async findOne(@Param('roomId') roomId: number): Promise<Room> {
     const result = await this.roomService.getRoom(roomId);
     return result;
+  }
+
+  @Get('/:roomId/member')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiParam({ name: 'roomId', type: Number })
+  @ApiOkResponse()
+  @ApiNotFoundResponse()
+  @ApiUnauthorizedResponse()
+  async findOneMember(@Param('roomId') roomId: number): Promise<MemberData[]> {
+    const result = await this.roomMemberService.getRoomMember(roomId);
+    return result.members;
   }
 
   @Put('/:roomId')

--- a/src/room/room.gateway.ts
+++ b/src/room/room.gateway.ts
@@ -21,6 +21,7 @@ import { RoomService } from './services/room.service';
 import { RoomError } from '../shared/errors/room.error';
 import { UserService } from '../user/user.service';
 import { UserError } from '../shared/errors/user.error';
+import { SocketEvent } from '../shared/socket/socket-event';
 
 @WebSocketGateway()
 export class RoomGateway {
@@ -33,7 +34,7 @@ export class RoomGateway {
   @WebSocketServer()
   server!: Server;
 
-  @SubscribeMessage('join')
+  @SubscribeMessage(SocketEvent.JOIN)
   async join(
     @ConnectedSocket() socket: Socket,
     @MessageBody() data: JoinSocketRequest
@@ -49,7 +50,7 @@ export class RoomGateway {
       socket.join(`room-${roomId}`);
 
       return {
-        event: 'join',
+        event: SocketEvent.JOIN,
         data: result
       };
     } catch (e) {
@@ -57,7 +58,7 @@ export class RoomGateway {
     }
   }
 
-  @SubscribeMessage('joinOwner')
+  @SubscribeMessage(SocketEvent.JOIN_OWNER)
   async joinOwner(
     @ConnectedSocket() socket: Socket,
     @MessageBody() data: JoinOwnerSocketRequest
@@ -83,7 +84,7 @@ export class RoomGateway {
       socket.join(`room-${roomId}`);
 
       return {
-        event: 'joinOwner',
+        event: SocketEvent.JOIN_OWNER,
         data: result
       };
     } catch (e) {
@@ -91,7 +92,7 @@ export class RoomGateway {
     }
   }
 
-  @SubscribeMessage('quit')
+  @SubscribeMessage(SocketEvent.QUIT)
   async quit(
     @ConnectedSocket() socket: Socket,
     @MessageBody() data: QuitSocketRequest
@@ -103,7 +104,7 @@ export class RoomGateway {
       socket.leave(`room-${roomId}`);
 
       return {
-        event: 'quit',
+        event: SocketEvent.QUIT,
         data: true
       };
     } catch (e) {
@@ -111,7 +112,7 @@ export class RoomGateway {
     }
   }
 
-  @SubscribeMessage('kick')
+  @SubscribeMessage(SocketEvent.KICK)
   async kick(
     @ConnectedSocket() socket: Socket,
     @MessageBody() data: KickSocketRequest
@@ -127,17 +128,16 @@ export class RoomGateway {
       const targetSocket = this.server.sockets.sockets[guest.socketId];
 
       targetSocket.leave(`room-${roomId}`);
-      targetSocket.emit('kickComplete', {
+      targetSocket.emit(SocketEvent.KICK_COMPLETE, {
         roomId: resultRoom,
         guestId: guest.id
       });
 
       return {
-        event: 'kick',
+        event: SocketEvent.KICK,
         data: true
       };
     } catch (e) {
-      Logger.error(e);
       throw new WsException(e.response || e.error);
     }
   }

--- a/src/room/room.gateway.ts
+++ b/src/room/room.gateway.ts
@@ -31,7 +31,7 @@ export class RoomGateway {
 
       const { roomId } = await this.roomService.getRoomByCode(inviteCode);
 
-      const result = await this.roomControllService.joinRoom(roomId, {
+      const result = await this.roomControllService.joinRoom(roomId, socket.client.id, {
         name
       });
       socket.join(`room-${roomId}`);

--- a/src/room/room.gateway.ts
+++ b/src/room/room.gateway.ts
@@ -8,9 +8,12 @@ import {
 } from '@nestjs/websockets';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Socket } from 'socket.io';
-import { JoinSocketRequest, QuitSocketRequest } from 'src/types/socket';
+import { JoinOwnerSocketRequest, JoinSocketRequest, QuitSocketRequest } from 'src/types/socket';
 import { RoomControllService } from './services/room-controll.service';
 import { RoomService } from './services/room.service';
+import { RoomError } from '../shared/errors/room.error';
+import { UserService } from '../user/user.service';
+import { UserError } from '../shared/errors/user.error';
 
 @WebSocketGateway({
   namespace: 'room'
@@ -18,8 +21,10 @@ import { RoomService } from './services/room.service';
 export class RoomGateway {
   constructor(
     private readonly roomService: RoomService,
-    private readonly roomControllService: RoomControllService
-  ) {}
+    private readonly roomControllService: RoomControllService,
+    private readonly userService: UserService
+  ) {
+  }
 
   @SubscribeMessage('join')
   async join(
@@ -38,6 +43,40 @@ export class RoomGateway {
 
       return {
         event: 'join',
+        data: result
+      };
+    } catch (e) {
+      throw new WsException(e.response || e.error);
+    }
+  }
+
+  @SubscribeMessage('joinOwner')
+  async joinOwner(
+    @ConnectedSocket() socket: Socket,
+    @MessageBody() data: JoinOwnerSocketRequest
+  ): Promise<WsResponse<unknown>> {
+    try {
+      const { roomId, ownerId } = data;
+
+      const existsUser = await this.userService.existsUserByUUID(ownerId);
+
+      if (!existsUser) {
+        throw new WsException(UserError.USER_NOT_FOUND);
+      }
+
+      const exists = await this.roomService.existsRoom(roomId);
+
+      if (!exists) {
+        throw new WsException(RoomError.ROOM_NOT_FOUND);
+      }
+
+      const result = await this.roomControllService.joinRoom(roomId, socket.client.id, {
+        userId: ownerId
+      });
+      socket.join(`room-${roomId}`);
+
+      return {
+        event: 'joinOwner',
         data: result
       };
     } catch (e) {

--- a/src/room/services/room-controll.service.ts
+++ b/src/room/services/room-controll.service.ts
@@ -5,11 +5,18 @@ import { RoomInteractReturn } from 'src/types';
 import { RoomMemberDocument } from '../room.schema';
 import { RoomMemberService } from './room-member.service';
 import { RoomService } from './room.service';
+import { MemberData } from '../../types/member-data';
 
 interface JoinRoomOption {
   readonly name?: string;
   readonly userId?: string;
 }
+
+interface KickReturn {
+    readonly roomId: number;
+    readonly guest: MemberData;
+}
+
 const WORD_DATA = 'abcdefghijklmnopqrstuvwxyz1234567890';
 
 @Injectable()
@@ -93,5 +100,23 @@ export class RoomControllService {
 
     roomMember.members.splice(guestIndex, 1);
     await roomMember.save();
+  }
+
+  async kickGuest(roomId: number, target: string): Promise<KickReturn> {
+    const existsRoom = await this.roomService.existsRoom(roomId);
+    if (!existsRoom) throw new WsException(RoomError.ROOM_NOT_FOUND);
+
+    const roomMember = await this.roomMemberService.getRoomMember(roomId);
+    const guest = roomMember.members.find((v) => v.id === target);
+
+    if (!guest) throw new WsException(RoomError.GUEST_NOT_FOUND);
+    if (guest.owner) throw new WsException(RoomError.OWNER_CAN_NOT_KICK);
+
+    await this.quitRoom(roomId, target);
+
+    return {
+      roomId,
+      guest
+    }
   }
 }

--- a/src/room/services/room-controll.service.ts
+++ b/src/room/services/room-controll.service.ts
@@ -45,7 +45,11 @@ export class RoomControllService {
     return roomMember;
   }
 
-  async joinRoom(roomId: number, options: JoinRoomOption): Promise<RoomInteractReturn> {
+  async joinRoom(
+    roomId: number,
+    socketId: string,
+    options: JoinRoomOption
+  ): Promise<RoomInteractReturn> {
     const isFull = await this.roomMemberService.isRoomFull(roomId);
     if (isFull) throw new WsException(RoomError.ROOM_IS_FULL);
 
@@ -61,6 +65,7 @@ export class RoomControllService {
     roomMember.members.push({
       id: guestOrUserId,
       owner: userId !== undefined,
+      socketId,
       name
     });
     await roomMember.save();

--- a/src/shared/errors/room.error.ts
+++ b/src/shared/errors/room.error.ts
@@ -1,6 +1,6 @@
 import { ErrorInfo } from 'src/types';
 
-export const RoomError: ErrorInfo = {
+export const RoomError = {
   ROOM_NOT_FOUND: {
     code: 'room-404',
     message: '존재하지 않는 방입니다.'

--- a/src/shared/errors/room.error.ts
+++ b/src/shared/errors/room.error.ts
@@ -32,5 +32,9 @@ export const RoomError: ErrorInfo = {
   OWNER_CAN_NOT_QUIT: {
     code: 'room-400',
     message: '방장은 방을 나갈 수 없습니다. 방 삭제를 이용해주세요.'
+  },
+  OWNER_CAN_NOT_KICK: {
+    code: 'room-400-1',
+    message: '방장은 추방할 수 없습니다.'
   }
 };

--- a/src/shared/socket/socket-event.ts
+++ b/src/shared/socket/socket-event.ts
@@ -1,0 +1,9 @@
+const events = {
+  JOIN: 'join',
+  JOIN_OWNER: 'joinOwner',
+  QUIT: 'quit',
+  KICK: 'kick',
+  KICK_COMPLETE: 'kickComplete'
+} as const;
+
+export const SocketEvent = events as Record<keyof typeof events, string>;

--- a/src/types/member-data.ts
+++ b/src/types/member-data.ts
@@ -1,5 +1,6 @@
 export interface MemberData {
   readonly id: string;
   readonly owner: boolean;
+  readonly socketId: string;
   name?: string;
 }

--- a/src/types/socket.ts
+++ b/src/types/socket.ts
@@ -12,3 +12,8 @@ export interface JoinOwnerSocketRequest {
   readonly roomId: number;
   readonly ownerId: string;
 }
+
+export interface KickSocketRequest {
+  readonly roomId: number;
+  readonly guestId: string;
+}

--- a/src/types/socket.ts
+++ b/src/types/socket.ts
@@ -7,3 +7,8 @@ export interface QuitSocketRequest {
   readonly roomId: number;
   readonly guestId: string;
 }
+
+export interface JoinOwnerSocketRequest {
+  readonly roomId: number;
+  readonly ownerId: string;
+}


### PR DESCRIPTION
- [Added] `GET /room/{roomId}/member` API 구현
- **[Fixed] 기존에는 방 생성 시 자동으로 방장 입장을 하였으나, 현재는 방장의 입장 처리를 별도로 해야됨. (using `joinOwner` socket)**
- [Added] `kick` 소켓을 통해 추방 가능. 추방 성공 시 추방 대상은 `kickComplete` 소켓을 받음. 이후 프론트엔드 처리 필요.
- **[Fixed] 소켓 namespace 삭제**
- Swagger 및 노션에 최신 내용 반영 완료