### PR TITLE
refactor: 에러 타입 및 에러코드 내용 수정

### DIFF
--- a/src/shared/errors/attendance.error.ts
+++ b/src/shared/errors/attendance.error.ts
@@ -1,6 +1,6 @@
 import { ErrorInfo } from 'src/types';
 
-export const AttendError: ErrorInfo = {
+const errors = {
   WRONG_ATTENDANCE_TYPE: {
     code: 'attend-404',
     message: '해당 attendance 타입은 존재하지 않습니다.'
@@ -8,5 +8,7 @@ export const AttendError: ErrorInfo = {
   ROOM_ALREADY_EXIST: {
     code: 'attend-409',
     message: '해당 방의 초대 코드가 이미 생성되어 있습니다.'
-  },
-};
+  }
+} as const;
+
+export const AttendError = errors as ErrorInfo<typeof errors>;

--- a/src/shared/errors/attendance.error.ts
+++ b/src/shared/errors/attendance.error.ts
@@ -2,11 +2,11 @@ import { ErrorInfo } from 'src/types';
 
 const errors = {
   WRONG_ATTENDANCE_TYPE: {
-    code: 'attend-404',
+    code: 'WRONG_ATTENDANCE_TYPE',
     message: '해당 attendance 타입은 존재하지 않습니다.'
   },
   ROOM_ALREADY_EXIST: {
-    code: 'attend-409',
+    code: 'ROOM_ALREADY_EXIST',
     message: '해당 방의 초대 코드가 이미 생성되어 있습니다.'
   }
 } as const;

--- a/src/shared/errors/auth.error.ts
+++ b/src/shared/errors/auth.error.ts
@@ -2,15 +2,15 @@ import { ErrorInfo } from 'src/types';
 
 const errors = {
   INVALID_TOKEN: {
-    code: 'auth-401',
+    code: 'INVALID_TOKEN',
     message: '유효하지 않은 토큰입니다.'
   },
   PERMISSION: {
-    code: 'auth-401-1',
+    code: 'PERMISSION',
     message: '권한이 없습니다.'
   },
   EMAIL_OR_PASSWORD_ERROR: {
-    code: 'auth-404',
+    code: 'EMAIL_OR_PASSWORD_ERROR',
     message: '없는 계정이거나 비밀번호가 올바르지 않습니다.'
   }
 } as const;

--- a/src/shared/errors/auth.error.ts
+++ b/src/shared/errors/auth.error.ts
@@ -1,6 +1,6 @@
 import { ErrorInfo } from 'src/types';
 
-export const AuthError: ErrorInfo = {
+const errors = {
   INVALID_TOKEN: {
     code: 'auth-401',
     message: '유효하지 않은 토큰입니다.'
@@ -13,4 +13,6 @@ export const AuthError: ErrorInfo = {
     code: 'auth-404',
     message: '없는 계정이거나 비밀번호가 올바르지 않습니다.'
   }
-};
+} as const;
+
+export const AuthError = errors as ErrorInfo<typeof errors>;

--- a/src/shared/errors/file.error.ts
+++ b/src/shared/errors/file.error.ts
@@ -1,6 +1,6 @@
 import { ErrorInfo } from 'src/types';
 
-export const FileError: ErrorInfo = {
+const errors = {
   FILE_UPLOAD_FAILED: {
     code: 'file-500',
     message: '업로드에 실패하였습니다.'
@@ -30,4 +30,6 @@ export const FileError: ErrorInfo = {
     code: 'file-500',
     message: '파일 삭제를 실패하였습니다'
   }
-};
+} as const;
+
+export const FileError = errors as ErrorInfo<typeof errors>;

--- a/src/shared/errors/file.error.ts
+++ b/src/shared/errors/file.error.ts
@@ -2,32 +2,32 @@ import { ErrorInfo } from 'src/types';
 
 const errors = {
   FILE_UPLOAD_FAILED: {
-    code: 'file-500',
+    code: 'FILE_UPLOAD_FAILED',
     message: '업로드에 실패하였습니다.'
   },
 
   FILE_CAPACITY_EXCEEDED: {
-    code: 'file-400',
+    code: 'FILE_CAPACITY_EXCEEDED',
     message: '업로드 할 수 있는 파일 용량을 초과하였습니다 (파일 하나당 100MB)'
   },
 
   FILE_STORAGE_NOT_FOUND: {
-    code: 'file-404',
+    code: 'FILE_STORAGE_NOT_FOUND',
     message: '해당 roomID를 가진 저장 스토리지가 존재하지 않습니다'
   },
 
   NULL_UPLOAD: {
-    code: 'file-400',
+    code: 'NULL_UPLOAD',
     message: '업로드된 파일이 없습니다'
   },
 
   FILE_STORAGE_DELETION_FAILED: {
-    code: 'file-500',
+    code: 'FILE_STORAGE_DELETION_FAILED',
     message: '파일 스토리지 삭제를 실패하였습니다'
   },
 
   FILE_DELETION_FAILED: {
-    code: 'file-500',
+    code: 'FILE_DELETION_FAILED',
     message: '파일 삭제를 실패하였습니다'
   }
 } as const;

--- a/src/shared/errors/room.error.ts
+++ b/src/shared/errors/room.error.ts
@@ -2,35 +2,35 @@ import { ErrorInfo } from 'src/types';
 
 const errors = {
   ROOM_NOT_FOUND: {
-    code: 'room-404',
+    code: 'ROOM_NOT_FOUND',
     message: '존재하지 않는 방입니다.'
   },
   ROOM_IS_FULL: {
-    code: 'room-409',
+    code: 'ROOM_IS_FULL',
     message: '방이 꽉찼습니다.'
   },
   INVITE_CODE_NOT_FOUND: {
-    code: 'room-404-1',
+    code: 'INVITE_CODE_NOT_FOUND',
     message: '올바르지 않은 초대코드입니다.'
   },
   GUEST_ALREADY_JOIN: {
-    code: 'room-409-1',
+    code: 'GUEST_ALREADY_JOIN',
     message: '같은 사용자가 이미 입장하였습니다.'
   },
   GUEST_NOT_FOUND: {
-    code: 'room-404-2',
+    code: 'GUEST_NOT_FOUND',
     message: '방에 입장하지 않은 사용자입니다.'
   },
   ROOM_NAME_USED: {
-    code: 'room-409-2',
+    code: 'ROOM_NAME_USED',
     message: '이미 사용 중인 방 이름입니다.'
   },
   ROOM_FAIL_INVITECODE: {
-    code: 'room-500',
+    code: 'ROOM_FAIL_INVITECODE',
     message: '초대코드 생성을 실패하였습니다. 다시 시도해주세요.'
   },
   OWNER_CAN_NOT_QUIT: {
-    code: 'room-400',
+    code: 'OWNER_CAN_NOT_QUIT',
     message: '방장은 방을 나갈 수 없습니다. 방 삭제를 이용해주세요.'
   }
 } as const;

--- a/src/shared/errors/room.error.ts
+++ b/src/shared/errors/room.error.ts
@@ -1,6 +1,6 @@
 import { ErrorInfo } from 'src/types';
 
-export const RoomError: ErrorInfo = {
+const errors = {
   ROOM_NOT_FOUND: {
     code: 'room-404',
     message: '존재하지 않는 방입니다.'
@@ -33,4 +33,6 @@ export const RoomError: ErrorInfo = {
     code: 'room-400',
     message: '방장은 방을 나갈 수 없습니다. 방 삭제를 이용해주세요.'
   }
-};
+} as const;
+
+export const RoomError = errors as ErrorInfo<typeof errors>;

--- a/src/shared/errors/user.error.ts
+++ b/src/shared/errors/user.error.ts
@@ -2,11 +2,11 @@ import { ErrorInfo } from 'src/types';
 
 const errors = {
   USER_NOT_FOUND: {
-    code: 'user-404',
+    code: 'USER_NOT_FOUND',
     message: '존재하지 않는 계정입니다.'
   },
   USER_ALREADY_EXISTS: {
-    code: 'user-409',
+    code: 'USER_ALREADY_EXISTS',
     message: '이미 존재하는 계정입니다.'
   }
 } as const;

--- a/src/shared/errors/user.error.ts
+++ b/src/shared/errors/user.error.ts
@@ -1,6 +1,6 @@
 import { ErrorInfo } from 'src/types';
 
-export const UserError: ErrorInfo = {
+const errors = {
   USER_NOT_FOUND: {
     code: 'user-404',
     message: '존재하지 않는 계정입니다.'
@@ -9,4 +9,6 @@ export const UserError: ErrorInfo = {
     code: 'user-409',
     message: '이미 존재하는 계정입니다.'
   }
-};
+} as const;
+
+export const UserError = errors as ErrorInfo<typeof errors>;

--- a/src/shared/errors/word.error.ts
+++ b/src/shared/errors/word.error.ts
@@ -1,8 +1,10 @@
 import { ErrorInfo } from 'src/types';
 
-export const WordError: ErrorInfo = {
+const errors = {
   WORD_NOT_FOUND: {
     code: 'word-404',
     message: '단어를 찾을 수 없습니다.'
   }
-};
+} as const;
+
+export const WordError = errors as ErrorInfo<typeof errors>;

--- a/src/shared/errors/word.error.ts
+++ b/src/shared/errors/word.error.ts
@@ -2,7 +2,7 @@ import { ErrorInfo } from 'src/types';
 
 const errors = {
   WORD_NOT_FOUND: {
-    code: 'word-404',
+    code: 'WORD_NOT_FOUND',
     message: '단어를 찾을 수 없습니다.'
   }
 } as const;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,7 +5,7 @@ interface ErrorDetail {
   code: string;
   message: string;
 }
-export type ErrorInfo = Record<string, ErrorDetail>;
+export type ErrorInfo<T extends Record<string, unknown>> = Record<keyof T, ErrorDetail>;
 
 export interface TokenReturn {
   readonly TOKEN: string;
@@ -31,7 +31,7 @@ export interface RoomInteractReturn {
   readonly roomInfo: Room;
 }
 
-export interface CreatedWordReturn{
+export interface CreatedWordReturn {
   readonly message: string;
   readonly count: number;
   readonly words: string[];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,11 +1,14 @@
 import { Room } from 'src/room/room.entity';
 import { User } from 'src/user/user.entity';
 
-interface ErrorDetail {
-  code: string;
+interface ErrorDetail<K extends string> {
+  code: Uppercase<K>;
   message: string;
 }
-export type ErrorInfo<T extends Record<string, unknown>> = Record<keyof T, ErrorDetail>;
+export type ErrorInfo<T extends Record<string, unknown>> = Record<
+  keyof T,
+  ErrorDetail<keyof T & string>
+>;
 
 export interface TokenReturn {
   readonly TOKEN: string;


### PR DESCRIPTION
- 기존 에러 타입 추론이 되지 않아 이를 해결하였습니다.
- 에러코드를 `{domain}-{statudcode}` 형태에서 에러 이름과 동일하도록 수정하였습니다.
  - 에러 이름과 에러 코드는 무조건 대문자이어야 합니다.
  - 어긋나는 이름이 있으면 컴파일이 되지 않습니다.
  - 해당 PR에는 수정해서 커밋하였습니다.