### PR TITLE
refactor: OAuth vendor를 타입을 이용하여 변경

### DIFF
--- a/src/auth/strategies/facebook.strategy.ts
+++ b/src/auth/strategies/facebook.strategy.ts
@@ -6,9 +6,10 @@ import { CreateUserDTO } from 'src/user/dto/create-user.dto';
 import { UserError } from 'src/shared/errors/user.error';
 import { User } from 'src/user/user.entity';
 import { UserService } from 'src/user/user.service';
+import { Vendor } from '../../types';
 
 @Injectable()
-export class FacebookStrategy extends PassportStrategy(Strategy, 'facebook') {
+export class FacebookStrategy extends PassportStrategy(Strategy, Vendor.FACEBOOK) {
   constructor(
     private readonly configService: ConfigService,
     private readonly userService: UserService
@@ -30,7 +31,7 @@ export class FacebookStrategy extends PassportStrategy(Strategy, 'facebook') {
 
     if (exists) {
       const user = await this.userService.findOneByEmail(email);
-      if (user.vendor !== 'facebook') {
+      if (user.vendor !== Vendor.FACEBOOK) {
         throw new ConflictException(UserError.USER_ALREADY_EXISTS);
       }
       return user;
@@ -39,7 +40,7 @@ export class FacebookStrategy extends PassportStrategy(Strategy, 'facebook') {
     const dto = new CreateUserDTO();
     dto.email = email;
     dto.name = name;
-    dto.vendor = 'facebook';
+    dto.vendor = Vendor.FACEBOOK;
 
     const createdUser = await this.userService.create(dto);
 

--- a/src/auth/strategies/google.strategy.ts
+++ b/src/auth/strategies/google.strategy.ts
@@ -6,9 +6,10 @@ import { CreateUserDTO } from 'src/user/dto/create-user.dto';
 import { UserError } from 'src/shared/errors/user.error';
 import { User } from 'src/user/user.entity';
 import { UserService } from 'src/user/user.service';
+import { Vendor } from '../../types';
 
 @Injectable()
-export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
+export class GoogleStrategy extends PassportStrategy(Strategy, Vendor.GOOGLE) {
   constructor(
     private readonly configService: ConfigService,
     private readonly userService: UserService
@@ -29,7 +30,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
 
     if (exists) {
       const user = await this.userService.findOneByEmail(email);
-      if (user.vendor !== 'google') {
+      if (user.vendor !== Vendor.GOOGLE) {
         throw new ConflictException(UserError.USER_ALREADY_EXISTS);
       }
       return user;
@@ -38,7 +39,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
     const dto = new CreateUserDTO();
     dto.email = email;
     dto.name = name;
-    dto.vendor = 'google';
+    dto.vendor = Vendor.GOOGLE;
 
     const createdUser = await this.userService.create(dto);
 

--- a/src/auth/strategies/kakao.strategy.ts
+++ b/src/auth/strategies/kakao.strategy.ts
@@ -6,9 +6,10 @@ import { CreateUserDTO } from 'src/user/dto/create-user.dto';
 import { UserError } from 'src/shared/errors/user.error';
 import { User } from 'src/user/user.entity';
 import { UserService } from 'src/user/user.service';
+import { Vendor } from '../../types';
 
 @Injectable()
-export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
+export class KakaoStrategy extends PassportStrategy(Strategy, Vendor.KAKAO) {
   constructor(
     private readonly configService: ConfigService,
     private readonly userService: UserService
@@ -29,7 +30,7 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
 
     if (exists) {
       const user = await this.userService.findOneByEmail(email);
-      if (user.vendor !== 'kakao') {
+      if (user.vendor !== Vendor.KAKAO) {
         throw new ConflictException(UserError.USER_ALREADY_EXISTS);
       }
       return user;
@@ -38,7 +39,7 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
     const dto = new CreateUserDTO();
     dto.email = email;
     dto.name = nickname;
-    dto.vendor = 'kakao';
+    dto.vendor = Vendor.KAKAO;
 
     const createdUser = await this.userService.create(dto);
 

--- a/src/auth/strategies/naver.strategy.ts
+++ b/src/auth/strategies/naver.strategy.ts
@@ -6,9 +6,10 @@ import { CreateUserDTO } from 'src/user/dto/create-user.dto';
 import { UserError } from 'src/shared/errors/user.error';
 import { User } from 'src/user/user.entity';
 import { UserService } from 'src/user/user.service';
+import { Vendor } from '../../types';
 
 @Injectable()
-export class NaverStrategy extends PassportStrategy(Strategy, 'naver') {
+export class NaverStrategy extends PassportStrategy(Strategy, Vendor.NAVER) {
   constructor(
     private readonly configService: ConfigService,
     private readonly userService: UserService
@@ -28,7 +29,7 @@ export class NaverStrategy extends PassportStrategy(Strategy, 'naver') {
 
     if (exists) {
       const user = await this.userService.findOneByEmail(email);
-      if (user.vendor !== 'naver') {
+      if (user.vendor !== Vendor.NAVER) {
         throw new ConflictException(UserError.USER_ALREADY_EXISTS);
       }
       return user;
@@ -37,7 +38,7 @@ export class NaverStrategy extends PassportStrategy(Strategy, 'naver') {
     const dto = new CreateUserDTO();
     dto.email = email;
     dto.name = nickname;
-    dto.vendor = 'naver';
+    dto.vendor = Vendor.NAVER;
 
     const createdUser = await this.userService.create(dto);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 import { Room } from 'src/room/room.entity';
 import { User } from 'src/user/user.entity';
+import { col } from 'sequelize';
 
 interface ErrorDetail {
   code: string;
@@ -31,8 +32,17 @@ export interface RoomInteractReturn {
   readonly roomInfo: Room;
 }
 
-export interface CreatedWordReturn{
+export interface CreatedWordReturn {
   readonly message: string;
   readonly count: number;
   readonly words: string[];
 }
+
+export const Vendor = {
+  NAVER: 'naver',
+  GOOGLE: 'google',
+  FACEBOOK: 'facebook',
+  KAKAO: 'kakao'
+} as const;
+
+export type VendorUnion = typeof Vendor[keyof typeof Vendor];

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsOptional, IsString } from 'class-validator';
+import { VendorUnion } from '../../types';
 
 export class CreateUserDTO {
   @IsEmail()
@@ -9,7 +10,7 @@ export class CreateUserDTO {
   @IsString()
   @IsOptional()
   @ApiProperty({ type: String, description: 'OAuth 소셜 종류', required: false })
-  vendor?: string;
+  vendor?: VendorUnion;
 
   @IsString()
   @IsOptional()

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -9,6 +9,7 @@ import { UserService } from './user.service';
 import { UserError } from '../shared/errors/user.error';
 import { User } from './user.entity';
 import { createUserMock } from '../utils/test.util';
+import { Vendor } from '../types';
 
 const mockRepository = () => ({
   find: jest.fn(),
@@ -42,7 +43,7 @@ describe('UserService', () => {
     it('소셜로그인을 이용하여 새로운 유저를 생성한다.', async () => {
       const createUserDto = {
         email: faker.internet.email(),
-        vendor: 'naver',
+        vendor: Vendor.NAVER,
         name: faker.name.findName()
       };
 
@@ -83,7 +84,7 @@ describe('UserService', () => {
     it('유저가 이미 존재하면 오류를 반환한다.', async () => {
       const createUserDto = {
         email: faker.internet.email(),
-        vendor: 'naver',
+        vendor: Vendor.NAVER,
         name: faker.name.findName()
       };
 


### PR DESCRIPTION
- 기존 문자열로 관리했던 vendor를 타입을 이용하도록 변경하였습니다.
- 벤더(vendor) 목록을 담고 있는 `Vendor` 타입과 이의 Union 타입인 `VendorUnion` 을 만들었습니다.